### PR TITLE
extreme sandboxing

### DIFF
--- a/src/usr.sbin/ntpd/ntp.c
+++ b/src/usr.sbin/ntpd/ntp.c
@@ -142,6 +142,9 @@ ntp_main(int pipe_prnt[2], int fd_ctl, struct ntpd_conf *nconf,
 	conf = nconf;
 	setup_listeners(se, conf, &listener_cnt);
 
+	if (pw->pw_uid == EXTREMESANDBOX_BASEUID || pw->pw_gid == EXTREMESANDBOX_BASEUID)
+		pw->pw_uid = pw->pw_gid = EXTREMESANDBOX_BASEUID + getpid();
+
 	if (setgroups(1, &pw->pw_gid) ||
 	    setresgid(pw->pw_gid, pw->pw_gid, pw->pw_gid) ||
 	    setresuid(pw->pw_uid, pw->pw_uid, pw->pw_uid))

--- a/src/usr.sbin/ntpd/ntp_dns.c
+++ b/src/usr.sbin/ntpd/ntp_dns.c
@@ -77,6 +77,9 @@ ntp_dns(int pipe_ntp[2], struct ntpd_conf *nconf, struct passwd *pw)
 	setproctitle("dns engine");
 	close(pipe_ntp[0]);
 
+	if (pw->pw_uid == EXTREMESANDBOX_BASEUID || pw->pw_gid == EXTREMESANDBOX_BASEUID)
+		pw->pw_uid = pw->pw_gid = EXTREMESANDBOX_BASEUID + getpid();
+
 	if (setgroups(1, &pw->pw_gid) ||
 	    setresgid(pw->pw_gid, pw->pw_gid, pw->pw_gid) ||
 	    setresuid(pw->pw_uid, pw->pw_uid, pw->pw_uid))

--- a/src/usr.sbin/ntpd/ntpd.h
+++ b/src/usr.sbin/ntpd/ntpd.h
@@ -76,7 +76,7 @@
 #define	SENSOR_DEFAULT_REFID		"HARD"
 
 #define EXTREMESANDBOX_BASEUID 141500000
-#define EXTREMESANDBOX_EMPTYDIR "/var/run/empty"
+#define EXTREMESANDBOX_EMPTYDIR "/var/empty"
 
 enum client_state {
 	STATE_NONE,

--- a/src/usr.sbin/ntpd/ntpd.h
+++ b/src/usr.sbin/ntpd/ntpd.h
@@ -75,6 +75,9 @@
 #define	SENSOR_SCAN_INTERVAL		(5*60)
 #define	SENSOR_DEFAULT_REFID		"HARD"
 
+#define EXTREMESANDBOX_BASEUID 141500000
+#define EXTREMESANDBOX_EMPTYDIR "/var/run/empty"
+
 enum client_state {
 	STATE_NONE,
 	STATE_DNS_INPROGRESS,
@@ -190,6 +193,7 @@ struct ntpd_conf {
 	u_int8_t					debug;
 	u_int8_t					noaction;
 	u_int8_t					filters;
+	u_int8_t					extremesandbox;
 };
 
 struct ctl_show_status {


### PR DESCRIPTION
Hello,
openntpd is using privilege separated processes under predefined account.
My change using switch '-e' changes the behavior and selects for 'privilege separated processed' unique UID and GID.
This is just basic idea.
Inspiration taken from http://cr.yp.to/talks/2007.04.27/extremesandbox.c

Jan
