### PR TITLE
fix err() argument to indicate error function name

### DIFF
--- a/src/usr.sbin/ntpd/ntpd.c
+++ b/src/usr.sbin/ntpd/ntpd.c
@@ -596,7 +596,7 @@ ctl_main(int argc, char *argv[])
 		err(1, "connect: %s", sockname);
 
 	if ((ibuf_ctl = malloc(sizeof(struct imsgbuf))) == NULL)
-		err(1, NULL);
+		err(1, "malloc: ");
 	imsg_init(ibuf_ctl, fd);
 
 	switch (action) {


### PR DESCRIPTION
fix err() argument to indicate error function name
