### PR TITLE
Cast to double to avoid overflow.

### DIFF
--- a/src/usr.sbin/ntpd/client.c
+++ b/src/usr.sbin/ntpd/client.c
@@ -258,7 +258,7 @@ client_dispatch(struct ntp_peer *p, u_int8_t settime)
 		if (cmsg->cmsg_level == SOL_SOCKET &&
 		    cmsg->cmsg_type == SCM_TIMESTAMP) {
 			memcpy(&tv, CMSG_DATA(cmsg), sizeof(tv));
-			T4 += tv.tv_sec + JAN_1970 + 1.0e-6 * tv.tv_usec;
+			T4 += (double)tv.tv_sec + JAN_1970 + 1.0e-6 * tv.tv_usec;
 			break;
 		}
 	}

--- a/src/usr.sbin/ntpd/util.c
+++ b/src/usr.sbin/ntpd/util.c
@@ -45,13 +45,13 @@ gettime(void)
 	if (gettimeofday(&tv, NULL) == -1)
 		fatal("gettimeofday");
 
-	return (tv.tv_sec + JAN_1970 + 1.0e-6 * tv.tv_usec);
+	return ((double)tv.tv_sec + JAN_1970 + 1.0e-6 * tv.tv_usec);
 }
 
 double
 gettime_from_timeval(struct timeval *tv)
 {
-	return (tv->tv_sec + JAN_1970 + 1.0e-6 * tv->tv_usec);
+	return ((double)tv->tv_sec + JAN_1970 + 1.0e-6 * tv->tv_usec);
 }
 
 time_t


### PR DESCRIPTION
When time is computed, (tv_sec + JAN_1970) can easily overflow into a 32bits machine.
We have to cast the first argument of the expression to be sure that the compute is made with a double.
For example, a date 2036 can be stored into the timeval structure. But adding JAN_1970, the type long is too short.

How to reproduce the bug:
# date -s 203603181700
# /usr/sbin/ntpd -sd

ntp engine ready
reply from 69.41.163.31: offset 3632192905.046063 delay 0.134022, next query 7s
reply from 199.167.29.243: offset 3632192905.038732 delay 0.149970, next query 9s
reply from 50.97.210.169: offset 3632192905.042741 delay 0.158570, next query 6s
settimeofday: Invalid argument
